### PR TITLE
Use PluginPlayer to model player state

### DIFF
--- a/src/mtg.js
+++ b/src/mtg.js
@@ -1,4 +1,5 @@
 import { putSpellOnTheStack } from "./castSpell";
+import { PluginPlayer } from "boardgame.io/plugins";
 
 const endIf = (G, ctx) => G.passedPriority.length === ctx.numPlayers;
 const onEnd = (G, ctx) => {
@@ -9,6 +10,7 @@ export const mtg = {
   setup: ctx => ({
     passedPriority: []
   }),
+  playerSetup: playerID => ({ playerID }),
   moves: {
     passPriority: (G, ctx) => {
       G.passedPriority.push(ctx.currentPlayer);
@@ -28,5 +30,6 @@ export const mtg = {
       endIf,
       onEnd
     }
-  }
+  },
+  plugins: [PluginPlayer]
 };


### PR DESCRIPTION
As I were reading through the [Plugin documentation](https://boardgame.io/documentation/#/plugins) I found the `PluginPlayer` that helps model player state

> Before each move, the plugin makes the state associated with the current player available at G.player. If this is a 2 player game, then it also adds G.opponent. These fields can be modified and the corresponding entries in G.players will be updated at the end of the move.

With this PR, the initial state looks like this:

```
{
  "passedPriority": [],
  "players": {
    "0": {
      "playerID": "0"
    },
    "1": {
      "playerID": "1"
    }
  }
}
```

