### PR TITLE
Add way to trigger card-related events

### DIFF
--- a/src/mtg-events.js
+++ b/src/mtg-events.js
@@ -1,0 +1,20 @@
+export const registerMtgEvents = (G, ...cardEvents) => {
+  for (let move in G.moves) {
+    const actualMove = G.moves[move];
+    const moveEvents = cardEvents.map(c => c.moves?.[move]).filter(e => !!e);
+    G.moves[move] = (G, ctx, ...args) => {
+      actualMove(G, ctx, ...args);
+      moveEvents.forEach(e => e(G, ctx, ...args));
+    };
+  }
+
+  for (let phase in G.phases) {
+    const actualOnBegin = G.phases[phase].onBegin || (() => {});
+    const phaseEvents = cardEvents.map(c => c.phases?.[phase]).filter(e => !!e);
+    G.phases[phase].onBegin = (G, ctx) => {
+      actualOnBegin(G, ctx);
+      phaseEvents.forEach(e => e(G, ctx));
+    };
+  }
+  return G;
+};

--- a/src/mtg-events.test.js
+++ b/src/mtg-events.test.js
@@ -1,0 +1,71 @@
+import { registerMtgEvents } from "./mtg-events";
+
+it("should be possible to create event for certain move", () => {
+  //Arrange
+  let actualMethodCalled = false;
+  let eventMethodCalled = false;
+  let actualCard = null;
+  let eventCard = null;
+
+  const game = {
+    moves: {
+      drawCard: (G, ctx, card) => {
+        actualMethodCalled = true;
+        actualCard = card;
+      }
+    }
+  };
+
+  const events = {
+    moves: {
+      drawCard: (G, ctx, card) => {
+        eventMethodCalled = true;
+        eventCard = card;
+      }
+    }
+  };
+
+  registerMtgEvents(game, events);
+
+  // Act
+  game.moves.drawCard(null, null, {});
+
+  // Assert
+  expect(actualMethodCalled).toBeTruthy();
+  expect(eventMethodCalled).toBeTruthy();
+  expect(actualCard).toBeTruthy();
+  expect(actualCard).toEqual(eventCard);
+});
+
+it("should be possible to create event for certain phase", () => {
+  // Arrange
+  let actualMethodCalled = false;
+  let eventMethodCalled = false;
+
+  const game = {
+    phases: {
+      untap: {
+        onBegin: (G, ctx) => {
+          actualMethodCalled = true;
+        }
+      }
+    }
+  };
+
+  const events = {
+    phases: {
+      untap: (G, ctx) => {
+        eventMethodCalled = true;
+      }
+    }
+  };
+
+  registerMtgEvents(game, events);
+
+  // Act
+  game.phases.untap.onBegin();
+
+  // Assert
+  expect(actualMethodCalled).toBeTruthy();
+  expect(eventMethodCalled).toBeTruthy();
+});


### PR DESCRIPTION
The idea being that it should be possible to encapsulate card related logic within the card module itself.

Consider for example a card with the ability that triggers whenever an opponent draws a card. It could be modeled like

```
{
  moves: {
    drawCard: (G, ctx) => {}
  }
}
```

Events can also be triggered upon entering phases

```
{
  phases: {
    untap: (G, ctx) => {}
  }
}
```

Thid is implemented by iterating over phases and moves and overriding existing `moves` and `onBegin` (for phases).