### PR TITLE
Add move to play land

### DIFF
--- a/src/mtg.js
+++ b/src/mtg.js
@@ -32,6 +32,7 @@ export const mtg = {
       onEnd
     },
     preCombatMainPhase: {
+      next: "upkeep",
       moves: {
         playLand
       }

--- a/src/mtg.js
+++ b/src/mtg.js
@@ -1,4 +1,5 @@
 import { putSpellOnTheStack } from "./castSpell";
+import { playLand } from "./play-land";
 import { PluginPlayer } from "boardgame.io/plugins";
 
 const endIf = (G, ctx) => G.passedPriority.length === ctx.numPlayers;
@@ -29,6 +30,11 @@ export const mtg = {
       next: "upkeep",
       endIf,
       onEnd
+    },
+    preCombatMainPhase: {
+      moves: {
+        playLand
+      }
     }
   },
   plugins: [PluginPlayer]

--- a/src/mtg.js
+++ b/src/mtg.js
@@ -27,7 +27,7 @@ export const mtg = {
       onEnd
     },
     draw: {
-      next: "upkeep",
+      next: "preCombatMainPhase",
       endIf,
       onEnd
     },

--- a/src/play-land.js
+++ b/src/play-land.js
@@ -1,0 +1,28 @@
+import { LAND } from "./permanents";
+
+export const playLand = (G, ctx, land) => {
+  if (!land?.types.some(t => t === LAND)) {
+    return;
+  }
+
+  // TODO: looking at 'turn' here does not suffice
+  // as it will change multiple times over the course
+  // of a mtg turn.
+  const landPlayedThisTurn = G.player.battlefield.some(
+    c => c.types.some(t => t === LAND) && c.turnPlayed === ctx.turn
+  );
+  if (landPlayedThisTurn) {
+    return;
+  }
+
+  const cardFromHand = G.player.hand.find(
+    c => c.instanceId === land.instanceId
+  );
+  if (!cardFromHand) {
+    return;
+  }
+
+  G.player.hand = G.player.hand.filter(c => c !== cardFromHand);
+  land.turnPlayed = ctx.turn;
+  G.player.battlefield.push(land);
+};

--- a/src/play-land.test.js
+++ b/src/play-land.test.js
@@ -3,14 +3,14 @@ import { Local } from "boardgame.io/multiplayer";
 import { mtg } from "./mtg";
 import { LAND } from "./permanents";
 
-const setup = playerStates => {
-  const game = { ...mtg };
+const setup = setupOverrides => {
+  const G = { ...mtg };
   const spec = {
-    game,
+    game: G,
     multiplayer: Local()
   };
 
-  setPlayerStates(game, playerStates);
+  setPlayerStates({ G, setupOverrides });
 
   const p0 = Client({ ...spec, playerID: "0" });
   const p1 = Client({ ...spec, playerID: "1" });
@@ -20,7 +20,7 @@ const setup = playerStates => {
   return { p0, p1 };
 };
 
-const setPlayerStates = (G, setupOverrides) => {
+const setPlayerStates = ({ G, setupOverrides }) => {
   const playerSetup = G.playerSetup;
   G.playerSetup = playerID => {
     const playerState = playerSetup(playerID);

--- a/src/play-land.test.js
+++ b/src/play-land.test.js
@@ -1,0 +1,96 @@
+import { Client } from "boardgame.io/client";
+import { Local } from "boardgame.io/multiplayer";
+import { mtg } from "./mtg";
+import { LAND } from "./permanents";
+
+const setup = playerStates => {
+  const game = { ...mtg };
+  const spec = {
+    game,
+    multiplayer: Local()
+  };
+
+  setPlayerStates(game, playerStates);
+
+  const p0 = Client({ ...spec, playerID: "0" });
+  const p1 = Client({ ...spec, playerID: "1" });
+
+  p0.start();
+  p1.start();
+  return { p0, p1 };
+};
+
+const setPlayerStates = (G, setupOverrides) => {
+  const playerSetup = G.playerSetup;
+  G.playerSetup = playerID => {
+    const playerState = playerSetup(playerID);
+
+    // TODO: null propegation?
+    if (!setupOverrides[playerID]) {
+      return playerState;
+    }
+
+    return setupOverrides[playerID](playerState);
+  };
+
+  if (setupOverrides.phase) {
+    for (let phase in G.phases) {
+      G.phases[phase].start = phase === setupOverrides.phase;
+    }
+  }
+};
+
+it("should not accept card that is not a land", () => {
+  // Arrange
+  const nonLandCard = { types: [] };
+  const { p0 } = setup({
+    phase: "preCombatMainPhase",
+    "0": state => ({ ...state, hand: [nonLandCard], battlefield: [] })
+  });
+
+  // Act
+  p0.moves.playLand(nonLandCard);
+
+  // Assert
+  const state = p0.getState().G;
+  expect(state.players["0"].battlefield).not.toContain(nonLandCard);
+  expect(state.players["0"].hand).toContain(nonLandCard);
+});
+
+it("should accept card of type LAND", () => {
+  // Arrange
+  const landCard = { types: [LAND], instanceId: 1 };
+  const { p0 } = setup({
+    phase: "preCombatMainPhase",
+    "0": state => ({ ...state, hand: [landCard], battlefield: [] })
+  });
+
+  // Act
+  p0.moves.playLand(landCard);
+
+  // Assert
+  const state = p0.getState().G;
+  expect(state.players["0"].battlefield).toContain(landCard);
+  expect(state.players["0"].hand).not.toContain(landCard);
+});
+
+it("should only be able to play one land per turn", () => {
+  // Arrange
+  const firstLand = { types: [LAND], instanceId: 1 };
+  const secondLand = { types: [LAND], instanceId: 2 };
+  const { p0 } = setup({
+    phase: "preCombatMainPhase",
+    "0": state => ({ ...state, hand: [firstLand, secondLand], battlefield: [] })
+  });
+
+  // Act
+  p0.moves.playLand(firstLand);
+  p0.moves.playLand(secondLand);
+
+  // Assert
+  const state = p0.getState().G;
+  expect(state.players["0"].battlefield).toContain(firstLand);
+  expect(state.players["0"].hand).not.toContain(firstLand);
+  expect(state.players["0"].battlefield).not.toContain(secondLand);
+  expect(state.players["0"].hand).toContain(secondLand);
+});


### PR DESCRIPTION
A first stab at creating the move `playLand`. There are also some ideas here that can be discussed:

* Whenever a permanent is placed on the battlefield, it gets a property `turnPlayed`, indicating when it was played. This is helpful for lands, but also for sagas.
* Types are modeled as an array of string. The rational for this is that cards can have multiple types, and it follows how cards are modeled in the MTG API.
* Introduced some sort of setup fixture in  the test that helps set the player state and advance the game to a specific state. This should perhaps be formalized at a later point