### PR TITLE
Add redux logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4039,6 +4039,11 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
+    "deep-diff": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
+      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
+    },
     "deep-equal": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
@@ -11626,6 +11631,14 @@
       "requires": {
         "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"
+      }
+    },
+    "redux-logger": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
+      "integrity": "sha1-91VZZvMJjzyIYExEnPC69XeCdL8=",
+      "requires": {
+        "deep-diff": "^0.3.5"
       }
     },
     "regenerate": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "boardgame.io": "^0.37.2",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
-    "react-scripts": "3.4.0"
+    "react-scripts": "3.4.0",
+    "redux-logger": "^3.0.6"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,8 @@ import React from "react";
 import { Client } from "boardgame.io/react";
 import { Local } from "boardgame.io/multiplayer";
 import { mtg } from "./mtg";
+import logger from "redux-logger";
+import { applyMiddleware } from "redux";
 
 const Label = ({ name, value }) => (
   <div>
@@ -19,7 +21,8 @@ const MtgClient = Client({
       <Label name="phase" value={props.ctx.phase}></Label>
       <button onClick={() => props.moves.passPriority()}>passPriority</button>
     </div>
-  )
+  ),
+  enhancer: applyMiddleware(logger)
 });
 
 const App = () => (

--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,7 @@ import { Client } from "boardgame.io/react";
 import { Local } from "boardgame.io/multiplayer";
 import { mtg } from "./mtg";
 import logger from "redux-logger";
-import { applyMiddleware } from "redux";
+import { applyMiddleware, compose } from "redux";
 
 const Label = ({ name, value }) => (
   <div>
@@ -22,7 +22,10 @@ const MtgClient = Client({
       <button onClick={() => props.moves.passPriority()}>passPriority</button>
     </div>
   ),
-  enhancer: applyMiddleware(logger)
+  enhancer: compose(
+    applyMiddleware(logger),
+    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+  )
 });
 
 const App = () => (


### PR DESCRIPTION
Adds [redux-logger](https://github.com/LogRocket/redux-logger), open the devtools to see actions and state-diffs. I prefer this to the [chrome plugin](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd) for debugging normally.

This configuration supports the chrome plugin as well, however.