### PR TITLE
Disables disallowing camelCase while the configuration is broken

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
         {
           "cases": {
             "kebabCase": true,
-            "ignore": [
-              "^setupTests\\.js$"
-            ]
+            "camelCase": true,
           }
         }
       ]

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         {
           "cases": {
             "kebabCase": true,
-            "camelCase": true,
+            "camelCase": true
           }
         }
       ]


### PR DESCRIPTION
@pardahlman This is temporary so we can get decent CI while the configuration is broken. I couldn't fix it yesterday.